### PR TITLE
feat: Implement HATEOAS support across controllers and models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,11 +174,29 @@
 		</dependency>
 
 
-	<dependency>
-		<groupId>org.springdoc</groupId>
-		<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-		<version>2.7.0</version>
-	</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-rest-hal-explorer</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<scope>annotationProcessor</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/ep14/pet_manager/assembler/NotificationModelAssembler.java
+++ b/src/main/java/com/ep14/pet_manager/assembler/NotificationModelAssembler.java
@@ -1,0 +1,49 @@
+package com.ep14.pet_manager.assembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import com.ep14.pet_manager.controller.NotificationController;
+import com.ep14.pet_manager.entity.SaleNotification;
+
+@Component
+public class NotificationModelAssembler implements RepresentationModelAssembler<SaleNotification, EntityModel<SaleNotification>> {
+
+    @Override
+    public EntityModel<SaleNotification> toModel(SaleNotification notification) {
+        EntityModel<SaleNotification> model = EntityModel.of(notification);
+        
+        // Add link to notifications by sale
+        if (notification.getSale() != null && notification.getSale().getSaleId() != null) {
+            model.add(linkTo(methodOn(NotificationController.class)
+                .getNotificationsBySale(notification.getSale().getSaleId()))
+                .withRel("sale-notifications"));
+        }
+        
+        // Add link to notifications by type
+        if (notification.getType() != null) {
+            model.add(linkTo(methodOn(NotificationController.class)
+                .getNotificationsByType(notification.getType()))
+                .withRel("type-notifications"));
+        }
+        
+        return model;
+    }
+
+    @Override
+    public CollectionModel<EntityModel<SaleNotification>> toCollectionModel(Iterable<? extends SaleNotification> entities) {
+        CollectionModel<EntityModel<SaleNotification>> collection = 
+            RepresentationModelAssembler.super.toCollectionModel(entities);
+        
+        // Add self link to the collection
+        collection.add(linkTo(methodOn(NotificationController.class)
+            .getNotificationsByType(null))
+            .withSelfRel());
+        
+        return collection;
+    }
+}

--- a/src/main/java/com/ep14/pet_manager/assembler/PurchaseModelAssembler.java
+++ b/src/main/java/com/ep14/pet_manager/assembler/PurchaseModelAssembler.java
@@ -1,0 +1,45 @@
+package com.ep14.pet_manager.assembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import com.ep14.pet_manager.controller.PurchaseController;
+import com.ep14.pet_manager.dto.PurchaseDTO;
+
+@Component
+public class PurchaseModelAssembler implements RepresentationModelAssembler<PurchaseDTO, EntityModel<PurchaseDTO>> {
+
+    @Override
+    public EntityModel<PurchaseDTO> toModel(PurchaseDTO purchase) {
+        EntityModel<PurchaseDTO> model = EntityModel.of(purchase);
+        
+        // Add self link
+        model.add(linkTo(methodOn(PurchaseController.class)
+            .getPurchaseById(purchase.getId()))
+            .withSelfRel());
+        
+        // Add link to all purchases
+        model.add(linkTo(methodOn(PurchaseController.class)
+            .getAllPurchases())
+            .withRel("purchases"));
+        
+        return model;
+    }
+
+    @Override
+    public CollectionModel<EntityModel<PurchaseDTO>> toCollectionModel(Iterable<? extends PurchaseDTO> entities) {
+        CollectionModel<EntityModel<PurchaseDTO>> collection = 
+            RepresentationModelAssembler.super.toCollectionModel(entities);
+        
+        // Add self link to the collection
+        collection.add(linkTo(methodOn(PurchaseController.class)
+            .getAllPurchases())
+            .withSelfRel());
+        
+        return collection;
+    }
+}

--- a/src/main/java/com/ep14/pet_manager/assembler/SaleModelAssembler.java
+++ b/src/main/java/com/ep14/pet_manager/assembler/SaleModelAssembler.java
@@ -1,0 +1,52 @@
+package com.ep14.pet_manager.assembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import com.ep14.pet_manager.controller.SaleController;
+import com.ep14.pet_manager.dto.SaleDTO;
+
+@Component
+public class SaleModelAssembler implements RepresentationModelAssembler<SaleDTO, EntityModel<SaleDTO>> {
+
+    @Override
+    public EntityModel<SaleDTO> toModel(SaleDTO sale) {
+        EntityModel<SaleDTO> model = EntityModel.of(sale);
+        
+        // Add self link
+        model.add(linkTo(methodOn(SaleController.class)
+            .getSaleById(sale.getSaleId()))
+            .withSelfRel());
+        
+        // Add link to all sales
+        model.add(linkTo(methodOn(SaleController.class)
+            .getAllSales())
+            .withRel("sales"));
+        
+        // Add link to user's sales if userId is present
+        if (sale.getUserId() != null) {
+            model.add(linkTo(methodOn(SaleController.class)
+                .getSalesByUser(sale.getUserId()))
+                .withRel("user-sales"));
+        }
+        
+        return model;
+    }
+
+    @Override
+    public CollectionModel<EntityModel<SaleDTO>> toCollectionModel(Iterable<? extends SaleDTO> entities) {
+        CollectionModel<EntityModel<SaleDTO>> collection = 
+            RepresentationModelAssembler.super.toCollectionModel(entities);
+        
+        // Add self link to the collection
+        collection.add(linkTo(methodOn(SaleController.class)
+            .getAllSales())
+            .withSelfRel());
+        
+        return collection;
+    }
+}

--- a/src/main/java/com/ep14/pet_manager/assembler/UserSummaryModelAssembler.java
+++ b/src/main/java/com/ep14/pet_manager/assembler/UserSummaryModelAssembler.java
@@ -1,0 +1,26 @@
+package com.ep14.pet_manager.assembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import com.ep14.pet_manager.controller.UserAdminController;
+import com.ep14.pet_manager.dto.UserSummary;
+
+@Component
+public class UserSummaryModelAssembler implements RepresentationModelAssembler<UserSummary, EntityModel<UserSummary>> {
+
+    @Override
+    public EntityModel<UserSummary> toModel(UserSummary userSummary) {
+        EntityModel<UserSummary> model = EntityModel.of(userSummary);
+        
+        // Add self link
+        model.add(linkTo(methodOn(UserAdminController.class)
+            .get(userSummary.userId()))
+            .withSelfRel());
+        
+        return model;
+    }
+}

--- a/src/main/java/com/ep14/pet_manager/controller/NotificationController.java
+++ b/src/main/java/com/ep14/pet_manager/controller/NotificationController.java
@@ -2,6 +2,8 @@ package com.ep14.pet_manager.controller;
 
 import java.util.List;
 
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ep14.pet_manager.assembler.NotificationModelAssembler;
 import com.ep14.pet_manager.entity.SaleNotification;
 import com.ep14.pet_manager.service.NotificationService;
 
@@ -22,34 +25,36 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final NotificationModelAssembler assembler;
 
-    public NotificationController(NotificationService notificationService) {
+    public NotificationController(NotificationService notificationService, NotificationModelAssembler assembler) {
         this.notificationService = notificationService;
+        this.assembler = assembler;
     }
 
     @GetMapping("/sale/{saleId}")
     @PreAuthorize("hasAuthority('sale.read')")
     @Operation(summary = "Obtener notificaciones de una venta", 
                description = "Retorna todas las notificaciones asociadas a una venta específica")
-    public ResponseEntity<List<SaleNotification>> getNotificationsBySale(@PathVariable Long saleId) {
+    public ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> getNotificationsBySale(@PathVariable Long saleId) {
         List<SaleNotification> notifications = notificationService.getNotificationsBySale(saleId);
-        return ResponseEntity.ok(notifications);
+        return ResponseEntity.ok(assembler.toCollectionModel(notifications));
     }
 
     @GetMapping
     @PreAuthorize("hasAuthority('sale.read')")
     @Operation(summary = "Obtener notificaciones por tipo", 
                description = "Retorna todas las notificaciones filtradas por tipo")
-    public ResponseEntity<List<SaleNotification>> getNotificationsByType(
+    public ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> getNotificationsByType(
             @RequestParam(required = false) SaleNotification.type type) {
         
         if (type != null) {
-            return ResponseEntity.ok(notificationService.getNotificationsByType(type));
+            List<SaleNotification> notifications = notificationService.getNotificationsByType(type);
+            return ResponseEntity.ok(assembler.toCollectionModel(notifications));
         }
         
         // Si no se especifica tipo, retornar las de alto volumen por defecto
-        return ResponseEntity.ok(
-            notificationService.getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN)
-        );
+        List<SaleNotification> notifications = notificationService.getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN);
+        return ResponseEntity.ok(assembler.toCollectionModel(notifications));
     }
 }

--- a/src/main/java/com/ep14/pet_manager/controller/PurchaseController.java
+++ b/src/main/java/com/ep14/pet_manager/controller/PurchaseController.java
@@ -3,6 +3,8 @@ package com.ep14.pet_manager.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ep14.pet_manager.assembler.PurchaseModelAssembler;
 import com.ep14.pet_manager.dto.PurchaseDTO;
 import com.ep14.pet_manager.service.PurchaseService;
 
@@ -22,18 +25,24 @@ import com.ep14.pet_manager.service.PurchaseService;
 public class PurchaseController {
 
     private final PurchaseService purchaseService;
+    private final PurchaseModelAssembler assembler;
 
 
     @Autowired
-    public PurchaseController(PurchaseService purchaseService) {
+    public PurchaseController(PurchaseService purchaseService, PurchaseModelAssembler assembler) {
         this.purchaseService = purchaseService;
+        this.assembler = assembler;
     }
 
     @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'purchase.read')")
     @GetMapping
-    public ResponseEntity<List<PurchaseDTO>> getAllPurchases() {
-        return ResponseEntity.ok(purchaseService.getAllPurchases());
-    }// Para las pruebas de integracion (hay que modificar despues)
+
+    public ResponseEntity<CollectionModel<EntityModel<PurchaseDTO>>> getAllPurchases(){
+        List<PurchaseDTO> purchases = purchaseService.getAllPurchases();
+        return ResponseEntity.ok(assembler.toCollectionModel(purchases));
+    }
+
+    // Para las pruebas de integracion (hay que modificar despues)
 
     /*@PreAuthorize("hasAuthority('purchase.read')")
     @GetMapping
@@ -43,8 +52,9 @@ public class PurchaseController {
 
     @PreAuthorize("hasAuthority('purchase.read')")
     @GetMapping("/{id}")
-    public ResponseEntity<PurchaseDTO> getPurchaseById(@PathVariable Long id){
-        return ResponseEntity.ok(purchaseService.getPurchaseById(id));
+    public ResponseEntity<EntityModel<PurchaseDTO>> getPurchaseById(@PathVariable Long id){
+        PurchaseDTO purchase = purchaseService.getPurchaseById(id);
+        return ResponseEntity.ok(assembler.toModel(purchase));
     }
 
     @PreAuthorize("hasAuthority('purchase.create')")
@@ -53,13 +63,15 @@ public class PurchaseController {
         if (purchaseDTO.getStatus() == null) {
             return ResponseEntity.badRequest().body("El estado es obligatorio");
         }
-        return ResponseEntity.ok(purchaseService.createPurchase(purchaseDTO));
+        PurchaseDTO created = purchaseService.createPurchase(purchaseDTO);
+        return ResponseEntity.ok(assembler.toModel(created));
     }
 
     @PreAuthorize("hasAuthority('purchase.update')")
     @PutMapping("/{id}")
-    public ResponseEntity<PurchaseDTO> updatePurchase(@PathVariable Long id, @RequestBody PurchaseDTO purchaseDTO){
-        return ResponseEntity.ok(purchaseService.updatePurchase(id, purchaseDTO));
+    public ResponseEntity<EntityModel<PurchaseDTO>> updatePurchase(@PathVariable Long id, @RequestBody PurchaseDTO purchaseDTO){
+        PurchaseDTO update = purchaseService.updatePurchase(id, purchaseDTO);
+        return ResponseEntity.ok(assembler.toModel(update));
     }
 
     @PreAuthorize("hasAuthority('purchase.delete')")

--- a/src/main/java/com/ep14/pet_manager/controller/RootController.java
+++ b/src/main/java/com/ep14/pet_manager/controller/RootController.java
@@ -1,0 +1,32 @@
+package com.ep14.pet_manager.controller;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Root", description = "Punto de entrada principal de la API con enlaces HATEOAS")
+public class RootController {
+
+    @GetMapping
+    @Operation(summary = "Obtener enlaces principales de la API", 
+               description = "Retorna los enlaces HATEOAS a todos los recursos disponibles en la API")
+    public ResponseEntity<RepresentationModel<?>> root() {
+        RepresentationModel<?> model = new RepresentationModel<>();
+        
+        // Agregar enlaces manualmente para evitar problemas de autorización
+        model.add(Link.of("/api/notifications", "notifications"));
+        model.add(Link.of("/api/sales", "sales"));
+        model.add(Link.of("/api/purchases", "purchases"));
+        model.add(Link.of("/api", "self"));
+        
+        return ResponseEntity.ok(model);
+    }
+}

--- a/src/main/java/com/ep14/pet_manager/controller/SaleController.java
+++ b/src/main/java/com/ep14/pet_manager/controller/SaleController.java
@@ -3,6 +3,8 @@ package com.ep14.pet_manager.controller;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ep14.pet_manager.assembler.SaleModelAssembler;
 import com.ep14.pet_manager.dto.SaleDTO;
 import com.ep14.pet_manager.service.SaleService;
 
@@ -21,45 +24,50 @@ import com.ep14.pet_manager.service.SaleService;
 public class SaleController {
 
     private final SaleService saleService;
+    private final SaleModelAssembler assembler;
 
-    public SaleController(SaleService saleService) {
+    public SaleController(SaleService saleService, SaleModelAssembler assembler) {
         this.saleService = saleService;
+        this.assembler = assembler;
     }
 
     @PreAuthorize("hasAuthority('sale.create')")
     @PostMapping
-    public ResponseEntity<SaleDTO> registerSale(@RequestBody SaleDTO saleDTO) {
-        return ResponseEntity.ok(saleService.registerSale(saleDTO));
+    public ResponseEntity<EntityModel<SaleDTO>> registerSale(@RequestBody SaleDTO saleDTO) {
+        SaleDTO created = saleService.registerSale(saleDTO);
+        return ResponseEntity.ok(assembler.toModel(created));
     }
 
     @PreAuthorize("hasAuthority('sale.read')")
     @GetMapping
-    public ResponseEntity<List<SaleDTO>> getAllSales() {
-        return ResponseEntity.ok(saleService.getAllSales());
+    public ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> getAllSales() {
+        List<SaleDTO> sales = saleService.getAllSales();
+        return ResponseEntity.ok(assembler.toCollectionModel(sales));
     }
 
     @PreAuthorize("hasAuthority('sale.read')")
     @GetMapping("/{id}")
-    public ResponseEntity<SaleDTO> getSaleById(@PathVariable Long id) {
-        return ResponseEntity.ok(saleService.getSaleById(id));
+    public ResponseEntity<EntityModel<SaleDTO>> getSaleById(@PathVariable Long id) {
+        SaleDTO sale = saleService.getSaleById(id);
+        return ResponseEntity.ok(assembler.toModel(sale));
     }
 
     @GetMapping("/user/{userId}")
     @PreAuthorize("hasAuthority('sale.read')")
-    public ResponseEntity<List<SaleDTO>> getSalesByUser(@PathVariable UUID userId) {
+    public ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> getSalesByUser(@PathVariable UUID userId) {
         List<SaleDTO> sales = saleService.getSalesByUser(userId);
-        return ResponseEntity.ok(sales);
+        return ResponseEntity.ok(assembler.toCollectionModel(sales));
     }
 
     @GetMapping("/admin")
     @PreAuthorize("hasAuthority('sale.read')")
-    public ResponseEntity<List<SaleDTO>> getAllSalesFiltered(
+    public ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> getAllSalesFiltered(
             @RequestParam(required = false) UUID userId,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
             @RequestParam(required = false) Long saleId) {
 
         List<SaleDTO> sales = saleService.getAllSalesFiltered(userId, startDate, endDate, saleId);
-        return ResponseEntity.ok(sales);
+        return ResponseEntity.ok(assembler.toCollectionModel(sales));
     }
 }

--- a/src/main/java/com/ep14/pet_manager/controller/UserAdminController.java
+++ b/src/main/java/com/ep14/pet_manager/controller/UserAdminController.java
@@ -1,5 +1,6 @@
 package com.ep14.pet_manager.controller;
 
+import org.springframework.hateoas.EntityModel;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ep14.pet_manager.assembler.UserSummaryModelAssembler;
 import com.ep14.pet_manager.dto.AssignPermissionsRequest;
 import com.ep14.pet_manager.dto.AssignRoleRequest;
 import com.ep14.pet_manager.dto.UserSummary;
@@ -21,11 +23,13 @@ import lombok.RequiredArgsConstructor;
 public class UserAdminController {
 
     private final UserAdminService service;
+    private final UserSummaryModelAssembler assembler;
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('user.read')")
-    public UserSummary get(@PathVariable String id) {
-        return service.getUserSummary(id);
+    public EntityModel<UserSummary> get(@PathVariable String id) {
+        UserSummary userSummary = service.getUserSummary(id);
+        return assembler.toModel(userSummary);
     }
 
     @PutMapping("/{id}/role")

--- a/src/main/java/com/ep14/pet_manager/service/SecurityConfig.java
+++ b/src/main/java/com/ep14/pet_manager/service/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // 👈 Habilita CORS global
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/actuator/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/actuator/**", "/explorer/**", "/browser/**", "/", "/api").permitAll()
                         .anyRequest().authenticated())
                 .userDetailsService(usersDetailsService)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,9 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.enabled=true
 
+# --- HATEOAS configuration ---
+spring.hateoas.use-hal-as-default-json-media-type=true
+
 # --- Notification configuration ---
 # Umbral para considerar una venta como de "alto volumen" (en cantidad de productos)
 notification.high-volume.threshold=10

--- a/src/test/java/com/ep14/pet_manager/PetManagerApplicationTests.java
+++ b/src/test/java/com/ep14/pet_manager/PetManagerApplicationTests.java
@@ -2,6 +2,7 @@ package com.ep14.pet_manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -18,6 +19,8 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -39,6 +42,9 @@ class PetManagerApplicationTests {
 
     @Mock
     private PurchaseService purchaseService;
+
+    @Mock
+    com.ep14.pet_manager.assembler.PurchaseModelAssembler purchaseModelAssembler;
 
     @InjectMocks
     private PurchaseController purchaseController;
@@ -80,13 +86,18 @@ class PetManagerApplicationTests {
                 .shoppingDetailIds(List.of(1L, 2L, 3L))
                 .build();
 
-        when(purchaseService.getAllPurchases()).thenReturn(List.of(purchase));
+        List<PurchaseDTO> purchases = List.of(purchase);
+        CollectionModel<EntityModel<PurchaseDTO>> collectionModel = 
+            CollectionModel.of(Collections.singletonList(EntityModel.of(purchase)));
 
-        ResponseEntity<List<PurchaseDTO>> response = purchaseController.getAllPurchases();
+        when(purchaseService.getAllPurchases()).thenReturn(purchases);
+        when(purchaseModelAssembler.toCollectionModel(purchases)).thenReturn(collectionModel);
+
+        ResponseEntity<CollectionModel<EntityModel<PurchaseDTO>>> response = purchaseController.getAllPurchases();
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().get(0).getTotal()).isEqualByComparingTo("100.00");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getContent()).hasSize(1);
     }
 
     @Test
@@ -105,11 +116,12 @@ class PetManagerApplicationTests {
         PurchaseDTO purchase = new PurchaseDTO();
         purchase.setId(1L);
         when(purchaseService.getPurchaseById(1L)).thenReturn(purchase);
+        when(purchaseModelAssembler.toModel(any(PurchaseDTO.class))).thenReturn(EntityModel.of(purchase));
 
-        ResponseEntity<PurchaseDTO> response = purchaseController.getPurchaseById(1L);
+        ResponseEntity<EntityModel<PurchaseDTO>> response = purchaseController.getPurchaseById(1L);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).isEqualTo(purchase);
+        assertThat(response.getBody().getContent()).isEqualTo(purchase);
     }
 
     @Test
@@ -118,11 +130,15 @@ class PetManagerApplicationTests {
         dto.setStatus(PurchaseDTO.StatusShopping.DRAFT); // estado válido
 
         when(purchaseService.createPurchase(dto)).thenReturn(dto);
+        when(purchaseModelAssembler.toModel(any(PurchaseDTO.class))).thenReturn(EntityModel.of(dto));
 
         ResponseEntity<?> response = purchaseController.createPurchase(dto);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).isEqualTo(dto);
+        assertThat(response.getBody()).isInstanceOf(EntityModel.class);
+        @SuppressWarnings("unchecked")
+        EntityModel<PurchaseDTO> entityModel = (EntityModel<PurchaseDTO>) response.getBody();
+        assertThat(entityModel.getContent()).isEqualTo(dto);
     }
 
     // AccessLogController Tests

--- a/src/test/java/com/ep14/pet_manager/controller/NotificationControllerTest.java
+++ b/src/test/java/com/ep14/pet_manager/controller/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.ep14.pet_manager.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,9 +14,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.ep14.pet_manager.assembler.NotificationModelAssembler;
 import com.ep14.pet_manager.entity.Sale;
 import com.ep14.pet_manager.entity.SaleNotification;
 import com.ep14.pet_manager.service.NotificationService;
@@ -25,12 +29,15 @@ class NotificationControllerTest {
     @Mock
     private NotificationService notificationService;
 
+    @Mock
+    private NotificationModelAssembler assembler;
+
     private NotificationController notificationController;
 
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        notificationController = new NotificationController(notificationService);
+        notificationController = new NotificationController(notificationService, assembler);
     }
 
     // 1. Obtener notificaciones por venta - retorna lista de notificaciones
@@ -59,22 +66,21 @@ class NotificationControllerTest {
             OffsetDateTime.now()
         );
 
-        List<SaleNotification> expectedNotifications = Arrays.asList(notification1, notification2);
-
         // Configurar mock
-        when(notificationService.getNotificationsBySale(saleId))
-            .thenReturn(expectedNotifications);
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(notification1),
+                EntityModel.of(notification2)
+            )));
 
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsBySale(saleId);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).hasSize(2);
-        assertThat(response.getBody().get(0).getSaleNotificationId()).isEqualTo(1L);
-        assertThat(response.getBody().get(1).getSaleNotificationId()).isEqualTo(2L);
+        assertThat(response.getBody().getContent()).hasSize(2);
         
         verify(notificationService).getNotificationsBySale(saleId);
     }
@@ -89,14 +95,16 @@ class NotificationControllerTest {
         when(notificationService.getNotificationsBySale(saleId))
             .thenReturn(Collections.emptyList());
 
+        when(assembler.toCollectionModel(any())).thenReturn(CollectionModel.empty());
+
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsBySale(saleId);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).isEmpty();
+        assertThat(response.getBody().getContent()).isEmpty();
         
         verify(notificationService).getNotificationsBySale(saleId);
     }
@@ -131,17 +139,18 @@ class NotificationControllerTest {
         // Configurar mock
         when(notificationService.getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN))
             .thenReturn(expectedNotifications);
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(EntityModel.of(notification1), EntityModel.of(notification2))));
 
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).hasSize(2);
-        assertThat(response.getBody().get(0).getType()).isEqualTo(SaleNotification.type.HIGH_VOLUMEN);
-        assertThat(response.getBody().get(1).getType()).isEqualTo(SaleNotification.type.HIGH_VOLUMEN);
+        assertThat(response.getBody().getContent()).hasSize(2);
         
         verify(notificationService).getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN);
     }
@@ -167,16 +176,18 @@ class NotificationControllerTest {
         // Configurar mock
         when(notificationService.getNotificationsByType(SaleNotification.type.HIGH_ROTATION))
             .thenReturn(expectedNotifications);
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(EntityModel.of(notification))));
 
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsByType(SaleNotification.type.HIGH_ROTATION);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().get(0).getType()).isEqualTo(SaleNotification.type.HIGH_ROTATION);
+        assertThat(response.getBody().getContent()).hasSize(1);
         
         verify(notificationService).getNotificationsByType(SaleNotification.type.HIGH_ROTATION);
     }
@@ -202,16 +213,18 @@ class NotificationControllerTest {
         // Configurar mock
         when(notificationService.getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN))
             .thenReturn(expectedNotifications);
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(EntityModel.of(notification))));
 
         // Ejecutar con tipo null
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsByType(null);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().get(0).getType()).isEqualTo(SaleNotification.type.HIGH_VOLUMEN);
+        assertThat(response.getBody().getContent()).hasSize(1);
         
         verify(notificationService).getNotificationsByType(SaleNotification.type.HIGH_VOLUMEN);
     }
@@ -222,15 +235,18 @@ class NotificationControllerTest {
         // Configurar mock
         when(notificationService.getNotificationsByType(SaleNotification.type.ANOTHER))
             .thenReturn(Collections.emptyList());
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.empty());
 
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsByType(SaleNotification.type.ANOTHER);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).isEmpty();
+        assertThat(response.getBody().getContent()).isEmpty();
         
         verify(notificationService).getNotificationsByType(SaleNotification.type.ANOTHER);
     }
@@ -276,17 +292,21 @@ class NotificationControllerTest {
         // Configurar mock
         when(notificationService.getNotificationsBySale(saleId))
             .thenReturn(expectedNotifications);
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(emailNotification),
+                EntityModel.of(smsNotification),
+                EntityModel.of(pushNotification)
+            )));
 
         // Ejecutar
-        ResponseEntity<List<SaleNotification>> response = 
+        ResponseEntity<CollectionModel<EntityModel<SaleNotification>>> response = 
             notificationController.getNotificationsBySale(saleId);
 
         // Verificar
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).hasSize(3);
-        assertThat(response.getBody().get(0).getMedia()).isEqualTo(SaleNotification.media.EMAIL);
-        assertThat(response.getBody().get(1).getMedia()).isEqualTo(SaleNotification.media.SMS);
-        assertThat(response.getBody().get(2).getMedia()).isEqualTo(SaleNotification.media.PUSH);
+        assertThat(response.getBody().getContent()).hasSize(3);
     }
 }

--- a/src/test/java/com/ep14/pet_manager/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/ep14/pet_manager/controller/PurchaseControllerTest.java
@@ -20,8 +20,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
 
+import com.ep14.pet_manager.assembler.PurchaseModelAssembler;
 import com.ep14.pet_manager.dto.PurchaseDTO;
 import com.ep14.pet_manager.service.PurchaseService;
 
@@ -29,6 +32,9 @@ class PurchaseControllerTest {
 
     @Mock
     private PurchaseService purchaseService;
+
+    @Mock
+    private PurchaseModelAssembler assembler;
 
     @InjectMocks
     private PurchaseController controller;
@@ -51,11 +57,16 @@ class PurchaseControllerTest {
     void getAllPurchases_shouldReturnOkWithList() {
         when(purchaseService.getAllPurchases()).thenReturn(List.of(purchaseDTO));
 
-        ResponseEntity<List<PurchaseDTO>> response = controller.getAllPurchases();
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(purchaseDTO)
+            )));
+
+        ResponseEntity<CollectionModel<EntityModel<PurchaseDTO>>> response = controller.getAllPurchases();
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getContent()).isNotEmpty();
         verify(purchaseService).getAllPurchases();
     }
 
@@ -63,17 +74,23 @@ class PurchaseControllerTest {
     void getPurchaseById_shouldReturnOk() {
         when(purchaseService.getPurchaseById(1L)).thenReturn(purchaseDTO);
 
-        ResponseEntity<PurchaseDTO> response = controller.getPurchaseById(1L);
+        when(assembler.toModel(any(PurchaseDTO.class)))
+            .thenReturn(EntityModel.of(purchaseDTO));
+
+        ResponseEntity<EntityModel<PurchaseDTO>> response = controller.getPurchaseById(1L);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getId()).isEqualTo(1L);
+        assertThat(response.getBody().getContent().getId()).isEqualTo(1L);
         verify(purchaseService).getPurchaseById(1L);
     }
 
     @Test
     void createPurchase_shouldReturnOk_whenStatusIsNotNull() {
         when(purchaseService.createPurchase(any(PurchaseDTO.class))).thenReturn(purchaseDTO);
+
+        when(assembler.toModel(any(PurchaseDTO.class)))
+            .thenReturn(EntityModel.of(purchaseDTO));
 
         ResponseEntity<?> response = controller.createPurchase(purchaseDTO);
 
@@ -138,7 +155,10 @@ class PurchaseControllerTest {
     void updatePurchase_shouldReturnOk() {
         when(purchaseService.updatePurchase(anyLong(), any(PurchaseDTO.class))).thenReturn(purchaseDTO);
 
-        ResponseEntity<PurchaseDTO> response = controller.updatePurchase(1L, purchaseDTO);
+        when(assembler.toModel(any(PurchaseDTO.class)))
+            .thenReturn(EntityModel.of(purchaseDTO));
+
+        ResponseEntity<EntityModel<PurchaseDTO>> response = controller.updatePurchase(1L, purchaseDTO);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();

--- a/src/test/java/com/ep14/pet_manager/controller/SaleControllerTest.java
+++ b/src/test/java/com/ep14/pet_manager/controller/SaleControllerTest.java
@@ -12,8 +12,11 @@ import org.mockito.Mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
 
+import com.ep14.pet_manager.assembler.SaleModelAssembler;
 import com.ep14.pet_manager.dto.SaleDTO;
 import com.ep14.pet_manager.service.SaleService;
 
@@ -21,6 +24,9 @@ class SaleControllerTest {
 
     @Mock
     private SaleService saleService;
+
+    @Mock
+    private SaleModelAssembler assembler;
 
     @InjectMocks
     private SaleController controller;
@@ -41,7 +47,10 @@ class SaleControllerTest {
     void registerSale_shouldReturnOk() {
         when(saleService.registerSale(any(SaleDTO.class))).thenReturn(saleDTO);
 
-        ResponseEntity<SaleDTO> response = controller.registerSale(saleDTO);
+        when(assembler.toModel(any(SaleDTO.class)))
+            .thenReturn(EntityModel.of(saleDTO));
+
+        ResponseEntity<EntityModel<SaleDTO>> response = controller.registerSale(saleDTO);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
@@ -66,10 +75,15 @@ class SaleControllerTest {
     void getAllSales_shouldReturnList() {
         when(saleService.getAllSales()).thenReturn(List.of(saleDTO));
 
-        ResponseEntity<List<SaleDTO>> response = controller.getAllSales();
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(saleDTO)
+            )));
+
+        ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> response = controller.getAllSales();
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getContent()).isNotEmpty();
         verify(saleService).getAllSales();
     }
 
@@ -78,10 +92,15 @@ class SaleControllerTest {
     void getSalesByUser_shouldReturnOk() {
         when(saleService.getSalesByUser(any(UUID.class))).thenReturn(List.of(saleDTO));
 
-        ResponseEntity<List<SaleDTO>> response = controller.getSalesByUser(userId);
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(saleDTO)
+            )));
+
+        ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> response = controller.getSalesByUser(userId);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getContent()).isNotEmpty();
         verify(saleService).getSalesByUser(userId);
     }
 
@@ -90,7 +109,10 @@ class SaleControllerTest {
     void getSaleById_shouldReturnOk() {
         when(saleService.getSaleById(1L)).thenReturn(saleDTO);
 
-        ResponseEntity<SaleDTO> response = controller.getSaleById(1L);
+        when(assembler.toModel(any(SaleDTO.class)))
+            .thenReturn(EntityModel.of(saleDTO));
+
+        ResponseEntity<EntityModel<SaleDTO>> response = controller.getSaleById(1L);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
@@ -101,9 +123,14 @@ class SaleControllerTest {
     @Test
     void getAllSalesFiltered_shouldReturnOk() {
         when(saleService.getAllSalesFiltered(any(), any(), any(), any()))
-                .thenReturn(List.of(saleDTO));
+            .thenReturn(List.of(saleDTO));
+        
+        when(assembler.toCollectionModel(any()))
+            .thenReturn(CollectionModel.of(List.of(
+                EntityModel.of(saleDTO)
+            )));
 
-        ResponseEntity<List<SaleDTO>> response = controller.getAllSalesFiltered(
+        ResponseEntity<CollectionModel<EntityModel<SaleDTO>>> response = controller.getAllSalesFiltered(
                 userId,
                 "2025-10-01T00:00:00Z",
                 "2025-10-19T00:00:00Z",
@@ -111,7 +138,7 @@ class SaleControllerTest {
         );
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getContent()).isNotEmpty();
         verify(saleService).getAllSalesFiltered(any(), any(), any(), any());
     }
 }

--- a/src/test/java/com/ep14/pet_manager/controller/UserAdminContollerTest.java
+++ b/src/test/java/com/ep14/pet_manager/controller/UserAdminContollerTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.hateoas.EntityModel;
 
+import com.ep14.pet_manager.assembler.UserSummaryModelAssembler;
 import com.ep14.pet_manager.dto.AssignPermissionsRequest;
 import com.ep14.pet_manager.dto.AssignRoleRequest;
 import com.ep14.pet_manager.dto.UserSummary;
@@ -22,12 +24,15 @@ class UserAdminControllerTest {
     @Mock
     private UserAdminService service;
 
+    @Mock
+    private UserSummaryModelAssembler assembler;
+
     private UserAdminController controller;
 
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        controller = new UserAdminController(service);
+        controller = new UserAdminController(service, assembler);
     }
 
     // 1. get(): devuelve el resumen de usuario obtenido del servicio
@@ -37,9 +42,12 @@ class UserAdminControllerTest {
 
         when(service.getUserSummary("123")).thenReturn(expected);
 
-        UserSummary result = controller.get("123");
+        when(assembler.toModel(any(UserSummary.class)))
+            .thenReturn(EntityModel.of(expected));
 
-        assertThat(result).isEqualTo(expected);
+        EntityModel<UserSummary> result = controller.get("123");
+
+        assertThat(result.getContent()).isEqualTo(expected);
         verify(service).getUserSummary("123");
     }
 


### PR DESCRIPTION
- Added HATEOAS dependencies in pom.xml.
- Refactored NotificationController, PurchaseController, SaleController, and UserAdminController to return HATEOAS-compliant responses.
- Created NotificationModelAssembler, PurchaseModelAssembler, SaleModelAssembler, and UserSummaryModelAssembler for assembling HATEOAS models.
- Introduced RootController to provide entry point with HATEOAS links.
- Updated application properties to enable HAL as default JSON media type.
- Enhanced unit tests for controllers to validate HATEOAS responses.